### PR TITLE
Fix/quadnode

### DIFF
--- a/src/main/java/com/graphicsengine/component/SpriteComponent.java
+++ b/src/main/java/com/graphicsengine/component/SpriteComponent.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import com.google.gson.annotations.SerializedName;
 import com.graphicsengine.spritemesh.SpriteMesh;
+import com.nucleus.SimpleLogger;
 import com.nucleus.component.Component;
 import com.nucleus.component.ComponentException;
 import com.nucleus.component.ComponentNode;
@@ -18,7 +19,6 @@ import com.nucleus.renderer.NucleusRenderer;
 import com.nucleus.scene.Node.MeshType;
 import com.nucleus.shader.ShaderProgram;
 import com.nucleus.shader.ShaderVariables;
-import com.nucleus.shader.VariableMapping;
 import com.nucleus.texturing.Texture2D;
 import com.nucleus.texturing.TextureType;
 import com.nucleus.texturing.UVAtlas;
@@ -59,6 +59,7 @@ public class SpriteComponent extends Component implements Consumer {
      * is copied to each vertice in the quad.
      * 
      * This shall match the shader variables used, normally in {@link ShaderVariables}
+     * TODO Perhaps remove this and use the values in the PropertyMapper instead?
      */
     public enum SpriteData {
         TRANSLATE(0),
@@ -318,8 +319,7 @@ public class SpriteComponent extends Component implements Consumer {
     }
 
     /**
-     * Sets the x, y and z position, this calls {@linkplain SpriteMesh#setPosition(int, float, float, float)} to update
-     * the attribute data
+     * Sets the x, y and z position
      * 
      * @param index The sprite number
      * @param x X position
@@ -331,13 +331,10 @@ public class SpriteComponent extends Component implements Consumer {
         spriteData[offset++ + SpriteData.TRANSLATE.index] = x;
         spriteData[offset++ + SpriteData.TRANSLATE.index] = y;
         spriteData[offset++ + SpriteData.TRANSLATE.index] = z;
-        spriteMesh.setAttribute3(index, mapper.translateOffset, spriteData,
-                index * spritedataSize + SpriteData.TRANSLATE.index);
     }
 
     /**
-     * Sets the frame number of the sprite index, this calls {@linkplain SpriteMesh#setFrame(int, int)} to update
-     * the attribute data
+     * Sets the frame number of the sprite index
      * 
      * @param index Index to the sprite object to set the frame on
      * @param frame Sprite frame number to set
@@ -345,30 +342,16 @@ public class SpriteComponent extends Component implements Consumer {
     public void setFrame(int index, int frame) {
         int offset = index * spritedataSize;
         spriteData[offset + SpriteData.FRAME.index] = frame;
-        spriteMesh.setAttribute1(index, mapper.frameOffset, spriteData,
-                index * spritedataSize + SpriteData.FRAME.index);
     }
 
     /**
-     * Sets attribute data for the specified sprite
-     * 
-     * @param index Index to the sprite to set attribute
-     * @param mapping The variable to set
-     * @param attribute
-     */
-    public void setAttribute4(int index, VariableMapping mapping, float[] attribute) {
-        // spriteMesh.setAttribute4(index, mapping, attribute);
-    }
-
-    /**
-     * Sets the color of the sprite, this calls {@linkplain SpriteMesh#setColor(int, float[])} to update the attribute
-     * data
+     * Sets the color of the sprite
      * 
      * @param index
      * @param rgba Array with at least 4 float values, index 0 is RED, 1 is GREEN, 2 is BLUE, 3 is ALPHA
      */
     public void setColor(int index, float[] rgba) {
-        // spriteMesh.setColor(index, rgba);
+        SimpleLogger.d(getClass(), "Not implemented!!!!!!!!!");
     }
 
     public void setRotateSpeed(int index, float speed) {
@@ -392,24 +375,28 @@ public class SpriteComponent extends Component implements Consumer {
         int offset = index * spritedataSize;
         spriteData[offset++ + SpriteData.SCALE.index] = x;
         spriteData[offset + SpriteData.SCALE.index] = y;
-        spriteMesh.setAttribute2(index, mapper.scaleOffset, spriteData,
-                index * spritedataSize + SpriteData.SCALE.index);
     }
 
     /**
-     * Sets the rotation, this calls {@linkplain SpriteMesh#setRotation(int, float)} to update
-     * the attribute data
+     * Sets the z axis rotation
      * 
      * @param index The sprite number
      * @param rotation
      */
-    public void setRotation(int index, float rotation) {
+    public void setRotationZ(int index, float rotation) {
         int offset = index * spritedataSize;
-        spriteData[offset + SpriteData.ROTATE.index] = rotation;
-        spriteMesh.setAttribute1(index, mapper.rotateOffset + 2, spriteData,
-                index * spritedataSize + SpriteData.ROTATE.index);
+        spriteData[offset + SpriteData.ROTATE.index + 2] = rotation;
     }
 
+    /**
+     * TODO - Implement method in SpriteMesh that copies all data for one sprite.
+     * 
+     * @param index
+     * @param x
+     * @param y
+     * @param frame
+     * @param rotate
+     */
     public void setSprite(int index, float x, float y, int frame, float rotate) {
         int offset = index * spritedataSize;
         spriteData[offset + SpriteData.TRANSLATE_X.index] = x;
@@ -423,7 +410,7 @@ public class SpriteComponent extends Component implements Consumer {
 
     @Override
     public void bindAttributeBuffer(AttributeBuffer buffer) {
-        attributeBuffer = spriteMesh.getVerticeBuffer(BufferIndex.ATTRIBUTES.index);
+        attributeBuffer = buffer;
         attributeData = new float[attributeBuffer.getCapacity()];
     }
 

--- a/src/main/java/com/graphicsengine/scene/QuadParentNode.java
+++ b/src/main/java/com/graphicsengine/scene/QuadParentNode.java
@@ -3,8 +3,12 @@ package com.graphicsengine.scene;
 import java.util.ArrayList;
 
 import com.google.gson.annotations.SerializedName;
+import com.graphicsengine.component.SpriteComponent;
 import com.graphicsengine.spritemesh.SpriteMesh;
+import com.nucleus.SimpleLogger;
 import com.nucleus.component.Component;
+import com.nucleus.geometry.AttributeBuffer;
+import com.nucleus.geometry.AttributeUpdater.Consumer;
 import com.nucleus.scene.Node;
 import com.nucleus.scene.RootNode;
 
@@ -13,16 +17,16 @@ import com.nucleus.scene.RootNode;
  * and use the mesh in the parent node to render the objects.
  * This means that they need to share the mesh in this node.
  * Use this node for simple objects that does not need to have special behavior. Use component node for that,
- * see {@linkplain Component}
+ * see {@linkplain Component} or {@link SpriteComponent}
  * This class can be serialized using GSON
  * 
  * @author Richard Sahlin
  *
  */
-public class QuadParentNode extends Node {
+public class QuadParentNode extends Node implements Consumer {
 
     public static final String MAX_QUADS = "maxQuads";
-    
+
     @SerializedName(MAX_QUADS)
     private int maxQuads;
 
@@ -38,7 +42,6 @@ public class QuadParentNode extends Node {
     private QuadParentNode(RootNode root) {
         super(root, GraphicsEngineNodeType.quadNode);
     }
-
 
     @Override
     public Node createInstance(RootNode root) {
@@ -89,6 +92,18 @@ public class QuadParentNode extends Node {
                 ((SharedMeshQuad) n).onCreated(mesh, index);
             }
         }
+        mesh.setAttributeUpdater(this);
+    }
+
+    @Override
+    public void updateAttributeData() {
+        SimpleLogger.d(getClass(), "update");
+    }
+
+    @Override
+    public void bindAttributeBuffer(AttributeBuffer buffer) {
+        // TODO Auto-generated method stub
+
     }
 
 }

--- a/src/main/java/com/graphicsengine/scene/QuadParentNode.java
+++ b/src/main/java/com/graphicsengine/scene/QuadParentNode.java
@@ -5,19 +5,26 @@ import java.util.ArrayList;
 import com.google.gson.annotations.SerializedName;
 import com.graphicsengine.component.SpriteComponent;
 import com.graphicsengine.spritemesh.SpriteMesh;
-import com.nucleus.SimpleLogger;
 import com.nucleus.component.Component;
 import com.nucleus.geometry.AttributeBuffer;
 import com.nucleus.geometry.AttributeUpdater.Consumer;
+import com.nucleus.geometry.AttributeUpdater.PropertyMapper;
+import com.nucleus.geometry.Mesh.BufferIndex;
+import com.nucleus.geometry.QuadExpander;
 import com.nucleus.scene.Node;
 import com.nucleus.scene.RootNode;
+import com.nucleus.texturing.Texture2D;
+import com.nucleus.texturing.TextureType;
+import com.nucleus.vecmath.Rectangle;
 
 /**
  * Node containing Quad elements, the intended usage is to group as many quad objects as possible under one node
  * and use the mesh in the parent node to render the objects.
  * This means that they need to share the mesh in this node.
- * Use this node for simple objects that does not need to have special behavior. Use component node for that,
- * see {@linkplain Component} or {@link SpriteComponent}
+ * Use this node for simple objects that does not need to have special behavior and not a large number of objects
+ * (roughly < 100) otherwise the overhead will grow.
+ * If a large number of objects are needed and/or special behavior then component node, see {@linkplain Component} or
+ * {@link SpriteComponent}
  * This class can be serialized using GSON
  * 
  * @author Richard Sahlin
@@ -31,6 +38,17 @@ public class QuadParentNode extends Node implements Consumer {
     private int maxQuads;
 
     transient private ArrayList<SharedMeshQuad> quadChildren = new ArrayList<>();
+    /**
+     * The sprites common float data storage, this is the sprite visible (mesh) properties such as position, scale and
+     * frame, plus entity data needed to process the logic.
+     * This is what is generally needed in order to put sprite on screen.
+     * In order to render a mesh with sprites this data is copied one -> four in the mesh.
+     */
+    transient public float[] spriteData;
+    transient protected int spritedataSize;
+    transient SpriteMesh spriteMesh;
+    transient PropertyMapper mapper;
+    transient QuadExpander quadExpander;
 
     /**
      * Used by GSON and {@link #createInstance(RootNode)} method - do NOT call directly
@@ -80,30 +98,71 @@ public class QuadParentNode extends Node implements Consumer {
         quadChildren.remove(quadMeshNode);
     }
 
+    /**
+     * Internal method
+     * Creates the arrays for this quad node
+     * 
+     * @param mesh
+     */
+    private void createBuffers(SpriteMesh mesh) {
+        mapper = mesh.getMapper();
+        spritedataSize = mapper.attributesPerVertex;
+        this.spriteData = new float[spritedataSize * maxQuads];
+        quadExpander = new QuadExpander(mesh.getTexture(Texture2D.TEXTURE_0), mapper, spriteData, spritedataSize,
+                maxQuads, 4);
+    }
+
+    /**
+     * Builds a quad for the specified quad index, if rectangle is null then size of texture is used.
+     * Initializes bounds
+     * 
+     * @param quad
+     * @param rectangle Rectangle to build quad from, if null then texture is used.
+     * @param The rectangle used to build the quad, same as rectangle if specified, otherwise texture rectangle.
+     */
+    public Rectangle buildQuad(int quad, Rectangle rectangle) {
+        Texture2D texture = spriteMesh.getTexture(Texture2D.TEXTURE_0);
+        if (rectangle == null && (texture.getTextureType() == TextureType.Untextured ||
+                texture.getWidth() == 0 || texture.getHeight() == 0)) {
+            // Must have size
+            throw new IllegalArgumentException("Node does not define RECT and texture is untextured or size is zero");
+        }
+        Rectangle quadRect = rectangle != null ? rectangle
+                : texture.calculateWindowRectangle();
+        spriteMesh.buildQuad(quad, spriteMesh.getMaterial().getProgram(), quadRect);
+        return quadRect;
+    }
+
     @Override
     public void onCreated() {
         super.onCreated();
-        // Setup all children in this node
-        SpriteMesh mesh = (SpriteMesh) getMesh(MeshType.MAIN);
+        spriteMesh = (SpriteMesh) getMesh(MeshType.MAIN);
+        spriteMesh.setAttributeUpdater(this);
+        bindAttributeBuffer(spriteMesh.getVerticeBuffer(BufferIndex.ATTRIBUTES.index));
+
+        // Setup all children in this node last
         for (Node n : getChildren()) {
             if (n instanceof SharedMeshQuad) {
                 // This is a special case since the mesh belongs to this node.
                 int index = addQuad((SharedMeshQuad) n);
-                ((SharedMeshQuad) n).onCreated(mesh, index);
+                ((SharedMeshQuad) n).onCreated(this, index);
             }
         }
-        mesh.setAttributeUpdater(this);
     }
 
     @Override
     public void updateAttributeData() {
-        SimpleLogger.d(getClass(), "update");
+        quadExpander.updateAttributeData();
     }
 
     @Override
     public void bindAttributeBuffer(AttributeBuffer buffer) {
-        // TODO Auto-generated method stub
+        createBuffers(spriteMesh);
+        quadExpander.bindAttributeBuffer(buffer);
+    }
 
+    public QuadExpander getExpander() {
+        return quadExpander;
     }
 
 }

--- a/src/main/java/com/graphicsengine/scene/SharedMeshQuad.java
+++ b/src/main/java/com/graphicsengine/scene/SharedMeshQuad.java
@@ -1,8 +1,10 @@
 package com.graphicsengine.scene;
 
 import com.google.gson.annotations.SerializedName;
+import com.graphicsengine.component.SpriteComponent;
 import com.graphicsengine.spritemesh.SpriteMesh;
 import com.nucleus.SimpleLogger;
+import com.nucleus.geometry.AttributeUpdater.PropertyMapper;
 import com.nucleus.scene.Node;
 import com.nucleus.scene.RootNode;
 import com.nucleus.texturing.Texture2D;
@@ -12,6 +14,8 @@ import com.nucleus.vecmath.Rectangle;
 /**
  * A Quad child that has to be appended to QuadNode in order to be rendered.
  * This node will share the mesh from the parent {@link QuadParentNode}
+ * This is for objects that are mostly static, for instance UI elements, and objects that need touch events.
+ * If a large number of objects with shared behavior are needed use {@link SpriteComponent} instead.
  * 
  * @author Richard Sahlin
  *
@@ -27,6 +31,7 @@ public class SharedMeshQuad extends Node {
      */
     transient private int childIndex;
     transient private SpriteMesh parentMesh;
+    transient private PropertyMapper mapper;
     /**
      * The rectangle defining the sprites, all sprites will have same size
      * 4 values = x1,y1 + width and height
@@ -56,6 +61,7 @@ public class SharedMeshQuad extends Node {
     public void onCreated(SpriteMesh mesh, int index) {
         this.childIndex = index;
         this.parentMesh = mesh;
+        this.mapper = mesh.getMapper();
         Texture2D texture = mesh.getTexture(Texture2D.TEXTURE_0);
         if (rectangle == null && (texture.getTextureType() == TextureType.Untextured ||
                 texture.getWidth() == 0 || texture.getHeight() == 0)) {
@@ -128,8 +134,7 @@ public class SharedMeshQuad extends Node {
      * @param frame
      */
     public void setFrame(int frame) {
-        SimpleLogger.d(getClass(), "---------------------------------MUST FIX----------------------------------");
-        // parentMesh.setFrame(childIndex, frame);
+        // parentMesh.setAttribute1(childIndex, mapper.frameOffset, , sourceIndex);
     }
 
 }

--- a/src/main/java/com/graphicsengine/scene/SharedMeshQuad.java
+++ b/src/main/java/com/graphicsengine/scene/SharedMeshQuad.java
@@ -2,13 +2,8 @@ package com.graphicsengine.scene;
 
 import com.google.gson.annotations.SerializedName;
 import com.graphicsengine.component.SpriteComponent;
-import com.graphicsengine.spritemesh.SpriteMesh;
-import com.nucleus.SimpleLogger;
-import com.nucleus.geometry.AttributeUpdater.PropertyMapper;
 import com.nucleus.scene.Node;
 import com.nucleus.scene.RootNode;
-import com.nucleus.texturing.Texture2D;
-import com.nucleus.texturing.TextureType;
 import com.nucleus.vecmath.Rectangle;
 
 /**
@@ -30,8 +25,7 @@ public class SharedMeshQuad extends Node {
      * The index of this shared mesh quad node with it's parent.
      */
     transient private int childIndex;
-    transient private SpriteMesh parentMesh;
-    transient private PropertyMapper mapper;
+    transient private QuadParentNode parent;
     /**
      * The rectangle defining the sprites, all sprites will have same size
      * 4 values = x1,y1 + width and height
@@ -55,32 +49,19 @@ public class SharedMeshQuad extends Node {
      * use it's own mesh
      * TODO Need to provide size and color from scene definition.
      * 
-     * @param mesh The source mesh
+     * @param Parent The parent node holding all quads
      * @param index
      */
-    public void onCreated(SpriteMesh mesh, int index) {
+    public void onCreated(QuadParentNode parent, int index) {
         this.childIndex = index;
-        this.parentMesh = mesh;
-        this.mapper = mesh.getMapper();
-        Texture2D texture = mesh.getTexture(Texture2D.TEXTURE_0);
-        if (rectangle == null && (texture.getTextureType() == TextureType.Untextured ||
-                texture.getWidth() == 0 || texture.getHeight() == 0)) {
-            // Must have size
-            throw new IllegalArgumentException("Node does not define RECT and texture is untextured or size is zero");
-        }
-        Rectangle quadRect = rectangle != null ? rectangle
-                : texture.calculateWindowRectangle();
-        mesh.buildQuad(index, mesh.getMaterial().getProgram(), quadRect);
-        initBounds(quadRect);
+        this.parent = parent;
+        initBounds(parent.buildQuad(index, rectangle));
         if (transform == null) {
-            SimpleLogger.d(getClass(), "---------------------------------MUST FIX----------------------------------");
-            // mesh.setScale(index, 1, 1);
+            parent.getExpander().setData(index, 0, 0, 0, 0, 1, 1, 1, frame);
         } else {
-            SimpleLogger.d(getClass(), "---------------------------------MUST FIX----------------------------------");
-            // mesh.setTransform(index, transform);
+            parent.getExpander().setData(index, transform);
+            parent.getExpander().setFrame(index, frame);
         }
-        SimpleLogger.d(getClass(), "---------------------------------MUST FIX----------------------------------");
-        // mesh.setFrame(index, frame);
         // if (mesh.getTexture(Texture2D.TEXTURE_0).textureType == TextureType.Untextured) {
         // mesh.setColor(index, getMaterial() != null ? getMaterial().getAmbient() : mesh.getMaterial().getAmbient());
         // }

--- a/src/main/java/com/graphicsengine/scene/SharedMeshQuad.java
+++ b/src/main/java/com/graphicsengine/scene/SharedMeshQuad.java
@@ -2,8 +2,11 @@ package com.graphicsengine.scene;
 
 import com.google.gson.annotations.SerializedName;
 import com.graphicsengine.component.SpriteComponent;
+import com.nucleus.geometry.Mesh;
 import com.nucleus.scene.Node;
 import com.nucleus.scene.RootNode;
+import com.nucleus.texturing.Texture2D;
+import com.nucleus.texturing.TextureType;
 import com.nucleus.vecmath.Rectangle;
 
 /**
@@ -62,9 +65,11 @@ public class SharedMeshQuad extends Node {
             parent.getExpander().setData(index, transform);
             parent.getExpander().setFrame(index, frame);
         }
-        // if (mesh.getTexture(Texture2D.TEXTURE_0).textureType == TextureType.Untextured) {
-        // mesh.setColor(index, getMaterial() != null ? getMaterial().getAmbient() : mesh.getMaterial().getAmbient());
-        // }
+        Mesh mesh = parent.getMesh(MeshType.MAIN);
+        if (mesh.getTexture(Texture2D.TEXTURE_0).textureType == TextureType.Untextured) {
+            parent.getExpander().setColor(index,
+                    getMaterial() != null ? getMaterial().getAmbient() : mesh.getMaterial().getAmbient());
+        }
     }
 
     /**
@@ -107,15 +112,6 @@ public class SharedMeshQuad extends Node {
      */
     private void setQuadRectangle(Rectangle rectangle) {
         this.rectangle = new Rectangle(rectangle);
-    }
-
-    /**
-     * Sets the frame number for this child.
-     * 
-     * @param frame
-     */
-    public void setFrame(int frame) {
-        // parentMesh.setAttribute1(childIndex, mapper.frameOffset, , sourceIndex);
     }
 
 }

--- a/src/main/java/com/graphicsengine/spritemesh/SpriteMesh.java
+++ b/src/main/java/com/graphicsengine/spritemesh/SpriteMesh.java
@@ -35,11 +35,6 @@ public class SpriteMesh extends Mesh {
      */
     // protected transient FloatBuffer attributeData;
 
-    /**
-     * Storage for 4 UV components
-     */
-    private transient float[] frames = new float[2 * 4];
-
     public static class Builder extends Mesh.Builder<SpriteMesh> {
 
         private final static String INVALID_TYPE = "Invalid type: ";
@@ -227,51 +222,6 @@ public class SpriteMesh extends Mesh {
         attributeBuffer.setArray(source, sourceIndex, index + offset, 2);
         index += mapper.attributesPerVertex;
         attributeBuffer.setArray(source, sourceIndex, index + offset, 2);
-        attributeBuffer.setDirty(true);
-    }
-
-    /**
-     * Copies 1 attribute value from the source array to the specified offset in sprite.
-     * This will update the mesh attributes, ie the data will be copied to 4 vertices.
-     * 
-     * @param sprite The sprite number
-     * @param offset Offset to attribute to set
-     * @param source The source array
-     * @param sourceIndex Index into source where data is copied from.
-     */
-    public void setAttribute1(int sprite, int offset, float[] source, int sourceIndex) {
-        int index = mapper.attributesPerVertex * 4 * sprite;
-        AttributeBuffer attributeBuffer = getVerticeBuffer(BufferIndex.ATTRIBUTES.index);
-        attributeBuffer.setArray(source, sourceIndex, index + offset, 1);
-        index += mapper.attributesPerVertex;
-        attributeBuffer.setArray(source, sourceIndex, index + offset, 1);
-        index += mapper.attributesPerVertex;
-        attributeBuffer.setArray(source, sourceIndex, index + offset, 1);
-        index += mapper.attributesPerVertex;
-        attributeBuffer.setArray(source, sourceIndex, index + offset, 1);
-        attributeBuffer.setDirty(true);
-    }
-
-    /**
-     * Copies data from the source array into the specified sprite. This will update the attributes, ie copying the
-     * data to 4 vertices.
-     * 
-     * @param sprite The sprite number
-     * @param offset Offset to attribute to set
-     * @param source Source data
-     * @param sourceIndex Index into source
-     * @param count Number of floats to copy
-     */
-    public void setData(int sprite, int offset, float[] source, int sourceIndex, int count) {
-        int index = mapper.attributesPerVertex * 4 * sprite;
-        AttributeBuffer attributeBuffer = getVerticeBuffer(BufferIndex.ATTRIBUTES.index);
-        attributeBuffer.setArray(source, sourceIndex, index + offset, count);
-        index += mapper.attributesPerVertex;
-        attributeBuffer.setArray(source, sourceIndex, index + offset, count);
-        index += mapper.attributesPerVertex;
-        attributeBuffer.setArray(source, sourceIndex, index + offset, count);
-        index += mapper.attributesPerVertex;
-        attributeBuffer.setArray(source, sourceIndex, index + offset, count);
         attributeBuffer.setDirty(true);
     }
 

--- a/src/main/resources/assets/shadow2flatvertex.essl
+++ b/src/main/resources/assets/shadow2flatvertex.essl
@@ -33,8 +33,6 @@ in vec4 aColor;
 out vec4 vLightPos;
 out vec4 color;
 
-precision mediump float;
-
 mat3 calculateTransformMatrix(vec3 rotate, vec3 scale);
 
 void main() {

--- a/src/main/resources/assets/shadow2texturedvertex.essl
+++ b/src/main/resources/assets/shadow2texturedvertex.essl
@@ -34,8 +34,6 @@ in vec2 aFrameData;//frame
 out vec2 vTexCoord;
 out vec4 vLightPos;
 
-precision mediump float;
-
 mat3 calculateTransformMatrix(vec3 rotate, vec3 scale);
 
 void main() {


### PR DESCRIPTION
Update how attributes are expanded into spritemesh, use a class to handle 1 -> 4 copy of vertex attributes and hide float[] from implementation.
This is to make it possible to add a compute shader / OpenCL program to do the attribute processing.

